### PR TITLE
Fix battle round progression

### DIFF
--- a/naruto_game/models/battle.py
+++ b/naruto_game/models/battle.py
@@ -158,7 +158,7 @@ class BattleState:
         
         # 使用技能
         success, result = self.selected_skill.use(self.current_character, self.selected_targets, self)
-        
+
         if success:
             if isinstance(result, list):
                 for msg in result:
@@ -170,6 +170,9 @@ class BattleState:
             if self.check_battle_end():
                 return True
                 
+            # 标记角色已行动
+            self.current_character.can_act = False
+
             # 重置选择
             self.selected_skill = None
             self.selected_targets = []
@@ -393,7 +396,10 @@ class BattleSystem:
         if not target.is_alive:
             result += f"，{target.name}倒下了！"
             self._check_battle_end(battle_state)
-        
+
+        # 标记角色已行动，防止本回合再次行动
+        user.can_act = False
+
         return result
     
     def get_valid_targets(self, battle_state, user, skill):

--- a/naruto_game/models/skills.py
+++ b/naruto_game/models/skills.py
@@ -84,7 +84,7 @@ class Skill:
                     for skill in character.skills:
                         if skill.type == 'CHASE' and skill.can_chase(target, chase_states):
                             # 执行追打
-                            chase_success, chase_result = skill.use([character], [target], battle_state)
+                            chase_success, chase_result = skill.use(character, [target], battle_state)
                             if chase_success:
                                 results.append(chase_result)
                                 # 更新目标状态，如果目标已经死亡则停止追打链


### PR DESCRIPTION
## Summary
- prevent characters from acting multiple times in the same turn
- ensure chase attacks call skill correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684564f39b988327bb1667cc4c88096d